### PR TITLE
FP32 LayerNorm for GPU

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Pax's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC
+NVIDIA Corporation

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,0 @@
-# This is the list of Pax's significant contributors.
-#
-# This does not necessarily list everyone who has contributed code,
-# especially since many employees of one corporation may be contributing.
-# To see the full list of contributors, see the revision history in
-# source control.
-Google LLC
-NVIDIA Corporation

--- a/praxis/layers/normalizations.py
+++ b/praxis/layers/normalizations.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2022 Google LLC.
+# Copyright 2022 The Pax Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/praxis/layers/normalizations.py
+++ b/praxis/layers/normalizations.py
@@ -306,7 +306,6 @@ class LayerNorm(BaseNormalization):
     use_bias: Whether to use bias.
     reductions_in_fp32: Whether to compute mean and variance 
       in fp32. Recommended for stable training on GPUs.
-
   """
   epsilon: float = 1e-6
   use_scale: bool = True

--- a/praxis/layers/normalizations.py
+++ b/praxis/layers/normalizations.py
@@ -304,10 +304,14 @@ class LayerNorm(BaseNormalization):
     epsilon: Tiny value to guard rsqrt.
     use_scale: Whether to use a learned scaling.
     use_bias: Whether to use bias.
+    reductions_in_fp32: Whether to compute mean and variance 
+      in fp32. Recommended for stable training on GPUs.
+
   """
   epsilon: float = 1e-6
   use_scale: bool = True
   use_bias: bool = True
+  reductions_in_fp32: bool = False
 
   def setup(self) -> None:
     """Creates layer normalization variables."""
@@ -358,9 +362,14 @@ class LayerNorm(BaseNormalization):
       'inputs'.
     """
     del paddings  # Unused.
+    if self.reductions_in_fp32:
+      inputs_dtype = inputs.dtype
+      inputs = inputs.astype(jnp.float32)
     mean = jnp.mean(inputs, axis=[-1], keepdims=True)
     var = jnp.mean(jnp.square(inputs - mean), axis=[-1], keepdims=True)
     normed_inputs = (inputs - mean) * jax.lax.rsqrt(var + self.epsilon)
+    if self.reductions_in_fp32:
+      normed_inputs = normed_inputs.astype(inputs_dtype)
     if self.use_scale:
       normed_inputs *= (1 + self.theta.scale)
     if self.use_bias:


### PR DESCRIPTION
Adds option to compute layernorm mean and variance using fp32. This is required for stable convergence on GPUs