### PR TITLE
Report Strict Accuracy Metric

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Pax's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC
+NVIDIA Corporation

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,0 @@
-# This is the list of Pax's significant contributors.
-#
-# This does not necessarily list everyone who has contributed code,
-# especially since many employees of one corporation may be contributing.
-# To see the full list of contributors, see the revision history in
-# source control.
-Google LLC
-NVIDIA Corporation

--- a/praxis/layers/models.py
+++ b/praxis/layers/models.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2022 Google LLC.
+# Copyright 2022 The Pax Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/praxis/layers/models.py
+++ b/praxis/layers/models.py
@@ -124,15 +124,15 @@ def compute_xent_loss_helper(
 
   num_acc = jnp.sum(weights, axis=-1, dtype=jnp.float32)
   ## mask out padding examples
-  num_acc = jax.lax.select(input_batch.eval_sample_weights.astype(jnp.int32), 
+  num_acc = jax.lax.select(input_batch.eval_sample_weights.astype(jnp.int32),
                            num_acc, jnp.inf*jnp.ones_like(num_acc))
-  num_nonpadding = jnp.sum(input_batch.eval_sample_weights) 
+  num_nonpadding = jnp.sum(input_batch.eval_sample_weights)
 
   mean_acc = jnp.sum(
       (labels == predicted_labels) * weights) / jnp.maximum(num_preds, 1)
   metric_weight = jnp.array(num_preds, predictions.avg_xent.dtype)
-    
-  mean_acc_strict = (jnp.sum(jnp.sum((labels == predicted_labels) 
+
+  mean_acc_strict = (jnp.sum(jnp.sum((labels == predicted_labels)
                                      * weights, axis=-1) == num_acc)
                      /jnp.maximum(num_nonpadding, 1))
   strict_weight = jnp.array(num_nonpadding, predictions.avg_xent.dtype)

--- a/praxis/layers/models.py
+++ b/praxis/layers/models.py
@@ -82,6 +82,7 @@ def compute_xent_loss_helper(
     input_batch: NestedMap,
     return_predictions: bool,
     apply_eval_sample_weights: bool = False,
+    report_strict_acc: bool = False,
 ) -> Tuple[WeightedScalars, Dict[str, Any]]:
   """Helper for computing the xent loss for Language model and Sequence model.
 
@@ -98,6 +99,8 @@ def compute_xent_loss_helper(
       example weights from the input `eval_sample_weights` or not. When enabled,
       these per-example weights will be merged with the per token
       `input_batch.weights`.
+    report_strict_acc: Whether to report strict accuracy. Used for eval on 
+      Lambada dataset.
 
   Returns:
     - A dict or NestedMap containing str keys and (value, weight) pairs as
@@ -118,9 +121,21 @@ def compute_xent_loss_helper(
         weights, input_batch.eval_sample_weights)
   predicted_labels = predictions.per_example_argmax.astype(labels.dtype)
   num_preds = predictions.total_weight
+
+  num_acc = jnp.sum(weights, axis=-1, dtype=jnp.float32)
+  ## mask out padding examples
+  num_acc = jax.lax.select(input_batch.eval_sample_weights.astype(jnp.int32), 
+                           num_acc, jnp.inf*jnp.ones_like(num_acc))
+  num_nonpadding = jnp.sum(input_batch.eval_sample_weights) 
+
   mean_acc = jnp.sum(
       (labels == predicted_labels) * weights) / jnp.maximum(num_preds, 1)
   metric_weight = jnp.array(num_preds, predictions.avg_xent.dtype)
+    
+  mean_acc_strict = (jnp.sum(jnp.sum((labels == predicted_labels) 
+                                     * weights, axis=-1) == num_acc)
+                     /jnp.maximum(num_nonpadding, 1))
+  strict_weight = jnp.array(num_nonpadding, predictions.avg_xent.dtype)
 
   if hasattr(predictions, 'avg_xent_weight'):
     avg_xent_weight = predictions.avg_xent_weight
@@ -136,6 +151,9 @@ def compute_xent_loss_helper(
       fraction_of_correct_next_step_preds=(mean_acc, metric_weight),
       num_predictions=(num_preds, jnp.array(1.0, num_preds.dtype)),
   )
+  if report_strict_acc:
+    metrics.acc_strict=(mean_acc_strict, strict_weight)
+
   # The score for the sequence is the negative of the sum of per token cross
   # entropy, which is the (weighted) sum of log probs on the tokens.
   per_example_output = NestedMap(
@@ -159,6 +177,8 @@ class LanguageModel(base_model.BaseModel):
     count_tokens: Whether to track total tokens trained on in the checkpoint.
     apply_eval_sample_weights: Boolean indicating whether to apply the per
       example weights from the input `eval_sample_weights` or not.
+    report_strict_acc: Whether to report strict accuracy. Used for eval on 
+      Lambada dataset.
   """
   lm_tpl: LayerTpl = template_field(transformer_models.TransformerLm)
   return_predictions: bool = False
@@ -166,6 +186,7 @@ class LanguageModel(base_model.BaseModel):
   model_type: LanguageModelType = LanguageModelType.CAUSAL
   count_tokens: bool = False
   apply_eval_sample_weights: bool = False
+  report_strict_acc: bool = False
 
   def setup(self) -> None:
     super().setup()
@@ -244,6 +265,7 @@ class LanguageModel(base_model.BaseModel):
         input_batch,
         self.return_predictions,
         self.apply_eval_sample_weights,
+        self.report_strict_acc,
     )
 
   def _prepare_guidance_decode_data(self, decode_data: NestedMap) -> NestedMap:


### PR DESCRIPTION
Adds option to report “strict accuracy” metric, which requires full sequence matching. This is needed for evaluation using the Lambada dataset.