### PR TITLE
Perform gradient clipping on global batch when using gradient accumulation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Pax's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC
+NVIDIA Corporation


### PR DESCRIPTION
Refactoring to allow gradient clipping to be performed on full batch rather than subbatches when using `ShardedStaticAccumulator`. Note that this refactor allows us to maintain support for `enable_skip_step_on_gradient_anomalies` and requires `x+1` grad norm calculations per global batch when using `ShardedStaticAccumulator` with `x` subbatches (once per subbatch to determine whether step should be skipped, once when applying gradient clipping in base optimizer update) and requires one grad clip per global batch.

This PR should be taken together with the corresponding Paxml PR.
