### PR TITLE
Adds a dev extra to make installing from git optional to not override an already installed fiddle/jax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup
 
 def _get_requirements():
   """Parses requirements.txt file."""
-  install_requires_tmp = []
+  install_requires_tmp, dev_requires_tmp = [], []
   with open(os.path.join(os.path.dirname(__file__), './requirements.in'),
             'r') as f:
     for line in f:
@@ -30,12 +30,15 @@ def _get_requirements():
       # Skip empty line or comments starting with "#".
       if not package_name or package_name[0] == '#':
         continue
+      elif ' @ ' in package_name:
+        dev_requires_tmp.append(package_name)
+        install_requires_tmp.append(package_name.partition(' @ ')[0])
       else:
         install_requires_tmp.append(package_name)
-  return install_requires_tmp
+  return install_requires_tmp, dev_requires_tmp
 
 
-install_requires = _get_requirements()
+install_requires, dev_requires = _get_requirements()
 
 setup(
     name='praxis',
@@ -48,6 +51,9 @@ setup(
     packages=find_packages(),
     python_requires='>=3.8',
     install_requires=install_requires,
+    extras_require={
+        'dev': dev_requires,
+    },
     url='https://github.com/google/praxis',
     license='Apache-2.0',
     classifiers=[


### PR DESCRIPTION
This change would allow a user who wants to install the head of `praxis` without overwriting previously installed fiddle or jax versions.

## Problem
Currently jax/fiddle are installed from github source via (e.g., `jax @ git+...`). This means installing `praxis` from source:
```bash
pip install ./praxis
```
Would pull from github and overwrite the installed jax version

## Proposal
Move the installs from github source (fiddle & jax) to a `dev` extra.

## User changes
This means `pip install ./praxis` would now no longer install from GH source and overwrite previously installed fiddle or jax installations. 

The old behavior is still maintained by passing the dev extra:
```bash
pip install './praxis[dev]'
```
So this would require those who installed `praxis` at head, to update their CI/scripts