### PR TITLE
Adds SKIP_HEAD_INSTALLS as an environment variable for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+# Set this envvar to avoid installing packages from head that can overwrite
+# existing installs of those packages, e.g., jax
+SKIP_HEAD_INSTALLS = os.environ.get('SKIP_HEAD_INSTALLS', '')
 
 def _get_requirements():
   """Parses requirements.txt file."""
@@ -29,7 +32,8 @@ def _get_requirements():
     for line in f:
       package_name = line.strip()
       # Skip empty line or comments starting with "#".
-      if not package_name or package_name[0] == '#':
+      if not package_name or package_name[0] == '#' \
+          or (' @ ' in package_name and SKIP_HEAD_INSTALLS):
         continue
       else:
         install_requires_tmp.append(package_name)


### PR DESCRIPTION
When set to a non-empty string, will skip adding packages that install the head version from github, which can overwrite an existing installation of that package. In this case, jax and fiddle will be skipped.

Assuming this change is acceptable, the same change would need to be made [in paxml](https://github.com/google/paxml/blob/main/requirements.in) as well since it also installs jax at head

@aireenmei