### PR TITLE
[Duplicate] Enhancements for transformer engine support

### DIFF
--- a/praxis/base_layer.py
+++ b/praxis/base_layer.py
@@ -1783,7 +1783,7 @@ class BaseLayer(nn.Module):
       *args,
       do_eval=False,
       method=None,
-      mutable=None,
+      extra_mutable_list=None,
       self_reflect_configs=False,
       **kwargs,
   ) -> Dict[str, NestedWeightHParams]:
@@ -1796,8 +1796,8 @@ class BaseLayer(nn.Module):
         if self_reflect_configs
         else DEFAULT_INIT_MUTABLE_LIST
     )
-    if mutable is not None:
-      mutable_list = [*mutable_list, *mutable]
+    if extra_mutable_list is not None:
+      mutable_list = [*mutable_list, *extra_mutable_list]
     init_fn = functools.partial(super().init, mutable=mutable_list, method=method)
     # Disable logging to reduce logspam.
     with py_utils.logging_verbosity_level('FATAL'):
@@ -1820,10 +1820,10 @@ class BaseLayer(nn.Module):
   # the unpadded variable shapes and SPMD annotations for
   # PARAMS and NON_TRAINABLE collections.
   def abstract_init_with_metadata(
-      self, *args, do_eval=False, method=None, mutable=None, **kwargs
+      self, *args, do_eval=False, method=None, extra_mutable_list=None, **kwargs
   ) -> NestedWeightHParams:
     variables_abstract = self._abstract_init(
-        *args, do_eval=do_eval, method=method, mutable=mutable, **kwargs
+        *args, do_eval=do_eval, method=method, extra_mutable_list=extra_mutable_list, **kwargs
     )
     # If model contains FlaxAdapter, we may see 'params_axes' collections, but
     # they do not contain WeightHParams, so we remove them from returned values.
@@ -1834,13 +1834,13 @@ class BaseLayer(nn.Module):
   # A systematic self-reflection of the model structure, with configs for the
   # nested tree of BaseLayers.
   def abstract_init_with_mdl_config(
-      self, *args, do_eval=False, method=None, mutable=None, **kwargs
+      self, *args, do_eval=False, method=None, extra_mutable_list=None, **kwargs
   ) -> Nested[pax_fiddle.Config[BaseLayer]]:
     variables_abstract = self._abstract_init(
         *args,
         do_eval=do_eval,
         method=method,
-        mutable=mutable,
+        extra_mutable_list=extra_mutable_list,
         self_reflect_configs=True,
         **kwargs,
     )

--- a/praxis/flax_utils.py
+++ b/praxis/flax_utils.py
@@ -15,7 +15,8 @@
 
 """Flax-related utils."""
 
-from typing import Optional
+import copy
+from typing import Optional, Dict, List
 
 from flax import traverse_util
 from flax.core import frozen_dict
@@ -63,6 +64,7 @@ def convert_to_boxed_params(
     var_tree: pytypes.PyTree,
     logical_axes_rules: Optional[pytypes.LogicalAxisRules] = None,
     mesh_shape=None,
+    var_collection_map: Dict[str, List[base_layer.WeightHParamsCollection]] = {},
 ) -> pytypes.PyTree:
   """Converts raw params into BoxedParams."""
   if logical_axes_rules is not None:
@@ -93,6 +95,8 @@ def convert_to_boxed_params(
               tuple(logical_axes), logical_axes_rules))
     if var_collection == base_layer.PARAMS:
       collections = []
+    elif var_collection in var_collection_map:
+      collections = copy.copy(var_collection_map[var_collection])
     else:
       # Here, we simply assume those vars are non-learnable and require mean
       # sync during training.

--- a/praxis/layers/flax_adapter.py
+++ b/praxis/layers/flax_adapter.py
@@ -18,7 +18,8 @@
 import abc
 import functools
 import typing
-from typing import Any, Callable, Optional
+from dataclasses import field
+from typing import Any, Callable, Dict, List, Optional
 
 import flax.linen as nn
 from flax.linen import partitioning as flax_partitioning
@@ -40,9 +41,13 @@ class _InternalBaseFlaxAdapter(base_layer.BaseLayer):
   Attributes:
     logical_axes_rules: Optional logical axes rules, e.g., [('input', 'mdl'),
       ('output', 'data')]
+    var_collection_map: Optional collection map for specific variables. Key is collection's name
+      and value is a list of base_layer.WeightHParamsCollection. e.g {"my_variables": [
+      WeightHParamsCollection.NON_TRAINABLE, WeightHParamsCollection.DISALLOW_BFLOAT16_CONVERSION]}.
   """
 
   logical_axes_rules: Optional[LogicalAxisRules] = None
+  var_collection_map: Dict[str, List[base_layer.WeightHParamsCollection]] = field(default_factory=dict) 
 
   if typing.TYPE_CHECKING:
 
@@ -86,6 +91,7 @@ class _InternalBaseFlaxAdapter(base_layer.BaseLayer):
             flax_utils.convert_to_boxed_params,
             logical_axes_rules=self.logical_axes_rules,
             mesh_shape=self.mesh_shape,
+            var_collection_map=self.var_collection_map,
         ),
     )
 


### PR DESCRIPTION
This PR adds the following enhancements which are needed for transformer engine support in Praxis:

1. Allow mutable list to be configurable in abstract_init_with_metadata and abstract_init_with_mdl_config.
2. Support custom WeightHParamsCollections to user-defined var_collections.