### PR TITLE
[NVIDIA] Add overwrite_with_gradient collection

### DIFF
--- a/praxis/base_layer.py
+++ b/praxis/base_layer.py
@@ -192,7 +192,21 @@ def var_skip_lp_regularization(var_params: ParamsT) -> bool:
 
 
 def var_overwrite_with_gradient(var_hparams: ParamsT) -> bool:
-  """Returns True if var_hparams overwrites with gradient."""
+  """Returns True if var_hparams is OWG (overwrite_with_gradient) variable.
+
+  OWG variables are semi-trainable; their new values are directly assigned as
+  `x = grad`. In other words, after each training step, they are overwritten by
+  the gradient value with respect to themselves. In contrast, regular trainable
+  variables are updated by the learner through the formula
+  `x = x + update(grad)`. Non-trainable variables, on the other hand, remain
+  unchanged, i.e., `x = x`.
+
+  Args:
+    var_hparams: WeightHParams used to create the variable.
+
+  Returns:
+    True if var_hparams belongs to OWG collection.
+  """
   return (WeightHParamsCollection.OVERWRITE_WITH_GRADIENT
           in var_hparams.collections)
 

--- a/praxis/base_layer.py
+++ b/praxis/base_layer.py
@@ -161,6 +161,7 @@ class WeightHParamsCollection:
   REQUIRES_MEAN_SYNC = '_requires_mean_sync'
   REQUIRES_SUM_SYNC = '_requires_sum_sync'
   DISALLOW_BFLOAT16_CONVERSION = '_disallow_bfloat16_conversion'
+  OVERWRITE_WITH_GRADIENT = '_overwrite_with_gradient'
 
 
 def var_not_trainable(var_hparams: ParamsT) -> bool:
@@ -188,6 +189,12 @@ def var_skip_lp_regularization(var_params: ParamsT) -> bool:
   return (
       WeightHParamsCollection.SKIP_LP_REGULARIZATION in var_params.collections
   )
+
+
+def var_overwrite_with_gradient(var_hparams: ParamsT) -> bool:
+  """Returns True if var_hparams overwrites with gradient."""
+  return (WeightHParamsCollection.OVERWRITE_WITH_GRADIENT
+          in var_hparams.collections)
 
 
 def to_partition_spec(


### PR DESCRIPTION
This PR provides the global constant string of overwrite_with_gradient and a helper function to check if the variable belongs to the category.

There are four related PRs, and should be reviewed in this order:
current-->(1) https://github.com/google/praxis/pull/29
(2) https://github.com/google/paxml/pull/48
(3) https://github.com/google/praxis/pull/28
(4) https://github.com/google/paxml/pull/49

cc. @pjannaty @reedwm @nluehr @lukaszlew