### PR TITLE
[NVIDIA] Use the fast accumulation for FP8 matmul

### DIFF
--- a/praxis/layers/injection/fp8_nvidia_gpu.py
+++ b/praxis/layers/injection/fp8_nvidia_gpu.py
@@ -103,7 +103,8 @@ class Fp8EinsumOp(base_layer.BaseLayer):
     k_qdq = fp8_ops.in_qdq(
         comp_dtype, k, theta.kernel_scale, theta.kernel_amax_history
     )
-    y_qdq = jnp.einsum(equation, x_qdq, k_qdq)
+    y_qdq = jnp.einsum(equation, x_qdq, k_qdq,
+                       _dot_general=fp8_ops.dot_general_with_precision)
     y = fp8_ops.out_qdq(
         comp_dtype,
         y_qdq,


### PR DESCRIPTION
As highlighted in [this issue](https://github.com/openxla/xla/issues/6168), this PR enables the use of fast accumulation for fprop FP8 matmul. This adjustment aligns with the changes implemented by Flax in [this PR](https://github.com/google/flax/pull/3416). It's important to note that this PR reuses the functions provided in the Flax change. Therefore, kindly consider merging this pull request after the completion of that one.

cc. @wenscarl @nluehr