### PR TITLE
Add Transformer Engine support to Praxis

### DIFF
--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
+++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
@@ -5,18 +5,25 @@ from praxis import pax_fiddle
 from praxis import pytypes
 
 try:
-  import transformer_engine.jax as te
-  import transformer_engine.jax.flax as te_flax
-  import transformer_engine.jax.praxis as te_praxis
-  _IS_TRANSFORMER_ENGINE_INSTALLED = True
-  import praxis.layers.repeats as praxis_repeat
-  # This is to make Repeat module correctly generate collections we need.
-  praxis_repeat.SCAN_VARIABLE_AXES.update({base_layer.NON_PAX_VAR_COLLECTION[1]: 0, # 1-idx = params_axes
-                                           te.fp8.FP8Helper.FP8_COLLECTION_NAME:0})
+    import transformer_engine.jax as te
+    import transformer_engine.jax.flax as te_flax
+    import transformer_engine.jax.praxis as te_praxis
+    _IS_TRANSFORMER_ENGINE_INSTALLED = True
+    import praxis.layers.repeats as praxis_repeat
+    # This is to make Repeat module correctly generate collections we need.
+    praxis_repeat.SCAN_VARIABLE_AXES.update({base_layer.NON_PAX_VAR_COLLECTION[1]: 0, # 1-idx = params_axes
+                                            te.fp8.FP8Helper.FP8_COLLECTION_NAME:0})
+    TE_PIPELINE_EXTRA_VMAP_VAR_AXES = {
+        base_layer.NON_PAX_VAR_COLLECTION[1]: 0, # 1-idx = params_axes
+        te.fp8.FP8Helper.FP8_COLLECTION_NAME:0
+    }
+
+    TE_PIPELINE_EXTRA_SCAN_VAR_BROADCAST = [te.fp8.FP8Helper.FP8_COLLECTION_NAME]
 
 except ModuleNotFoundError as e:
-  _IS_TRANSFORMER_ENGINE_INSTALLED = False
-
+    _IS_TRANSFORMER_ENGINE_INSTALLED = False
+    TE_PIPELINE_EXTRA_VMAP_VAR_AXES = {}
+    TE_PIPELINE_EXTRA_SCAN_VAR_BROADCAST = []
 
 LayerTpl = pax_fiddle.Config[base_layer.BaseLayer]
 JTensor = pytypes.JTensor
@@ -136,8 +143,9 @@ class TEInstalledHelper(TransformerEngineHelperBase):
     @staticmethod
     def get_bld_mapping_for_pipelined_transformer(_):
         rules = te_flax.extend_logical_axis_rules(tuple())
-        batch_mapping = rules[0]
-        hidden_tp_mapping = rules[4]
+        # rules [(batch_axis_name, ('replicat', 'data'))', ...)]
+        batch_mapping = rules[0][1]
+        hidden_tp_mapping = rules[4][1]
         # [Batch, Seqlen, Hidden]
         bld_mapping = [batch_mapping, None, hidden_tp_mapping]
         return bld_mapping
@@ -172,5 +180,3 @@ class TransformerEngineHelper(TransformerEngineHelperBase):
     def get_bld_mapping_for_pipelined_transformer(xformer_layer_p):
         return TransformerEngineHelper.get_helper().get_bld_mapping_for_pipelined_transformer(
                     xformer_layer_p)
-
-

--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
+++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
@@ -1,0 +1,176 @@
+import os
+
+from praxis import base_layer
+from praxis import pax_fiddle
+from praxis import pytypes
+
+try:
+  import transformer_engine.jax as te
+  import transformer_engine.jax.flax as te_flax
+  import transformer_engine.jax.praxis as te_praxis
+  _IS_TRANSFORMER_ENGINE_INSTALLED = True
+  import praxis.layers.repeats as praxis_repeat
+  # This is to make Repeat module correctly generate collections we need.
+  praxis_repeat.SCAN_VARIABLE_AXES.update({base_layer.NON_PAX_VAR_COLLECTION[1]: 0, # 1-idx = params_axes
+                                           te.fp8.FP8Helper.FP8_COLLECTION_NAME:0})
+
+except ModuleNotFoundError as e:
+  _IS_TRANSFORMER_ENGINE_INSTALLED = False
+
+
+LayerTpl = pax_fiddle.Config[base_layer.BaseLayer]
+JTensor = pytypes.JTensor
+
+
+class TransformerEngineHelperBase:
+
+    @staticmethod
+    def get_fprop_caller_of_stack_transformer(fprop, deterministic):
+        raise NotImplementedError
+
+    @staticmethod
+    def set_layer_params_to_stack_transformer(stacked_transformer_obj, layer_p, layer_id):
+        raise NotImplementedError
+
+    @staticmethod
+    def get_bld_mapping_for_pipelined_transformer(xformer_layer_p):
+        raise NotImplementedError
+
+
+
+class TENotInstalledHelper(TransformerEngineHelperBase):
+
+    @staticmethod
+    def get_fprop_caller_of_stack_transformer(fprop, deterministic):
+        return fprop
+
+    @staticmethod
+    def set_layer_params_to_stack_transformer(stacked_transformer_obj, layer_p, layer_id):
+        layer_p.name = f'layer_{layer_id}'
+        layer_p.use_cross_attention = stacked_transformer_obj.use_cross_attention
+        layer_p.num_heads = stacked_transformer_obj.num_heads
+        layer_p.dim_per_head = stacked_transformer_obj.dim_per_head
+        layer_p.input_dims = stacked_transformer_obj.model_dims
+        layer_p.packed_input = stacked_transformer_obj.packed_input
+        layer_p.atten_dropout_prob = stacked_transformer_obj.atten_dropout_prob or stacked_transformer_obj.dropout_prob
+        layer_p.residual_dropout_prob = (
+            stacked_transformer_obj.residual_dropout_prob or stacked_transformer_obj.dropout_prob
+        )
+        layer_p.relu_dropout_prob = stacked_transformer_obj.relu_dropout_prob or stacked_transformer_obj.dropout_prob
+        layer_p.hidden_dims = stacked_transformer_obj.hidden_dims
+
+        if stacked_transformer_obj.residual_droppath_prob > 0.0:
+            layer_p.residual_droppath_prob = (
+                stacked_transformer_obj.residual_droppath_prob * layer_id / max(1, stacked_transformer_obj.num_layers)
+            )
+        return layer_p
+
+    @staticmethod
+    def get_bld_mapping_for_pipelined_transformer(xformer_layer_p):
+        return xformer_layer_p.tr_atten_tpl.activation_split_dims_mapping.bld
+
+
+class TEInstalledHelper(TransformerEngineHelperBase):
+
+    @staticmethod
+    def get_fprop_caller_of_stack_transformer(_, deterministic):
+        def _fprop(
+            transformer,
+            x_in,
+            paddings,
+            attention_mask,
+            cross_inputs,
+            cross_attention_mask,
+            segment_pos
+        ):
+            x_out = transformer(
+                inputs=x_in,
+                attention_mask=attention_mask,
+                encoded=cross_inputs,
+                encoder_decoder_mask=cross_attention_mask,
+                deterministic=deterministic)
+            return x_out
+        return _fprop
+
+
+    @staticmethod
+    def set_layer_params_to_stack_transformer(stacked_transformer_obj, _, layer_id):
+        te_transformer_tpl = pax_fiddle.Config(te_praxis.TransformerLayer,
+            name=f'layer_{layer_id}',
+            layernorm_type='layernorm',
+            zero_centered_gamma = True,
+            mlp_activations=('gelu',),
+            use_bias=True,
+            self_attn_mask_type='causal',
+            enable_relative_embedding=False,
+            scaled_query_init=False,
+            scale_attn_logits=True,
+            transpose_batch_sequence=False
+        )
+
+        te_transformer_tpl.logical_axes_rules = te_flax.extend_logical_axis_rules(tuple())
+        te_transformer_tpl.params_init = stacked_transformer_obj.params_init
+        te_transformer_tpl.dtype = stacked_transformer_obj.fprop_dtype
+        te_transformer_tpl.layer_type = te_praxis.TransformerLayerType.DECODER if stacked_transformer_obj.use_cross_attention \
+                        else te_praxis.TransformerLayerType.ENCODER
+        te_transformer_tpl.num_attention_heads = stacked_transformer_obj.num_heads
+        te_transformer_tpl.hidden_size = stacked_transformer_obj.model_dims
+        te_transformer_tpl.mlp_hidden_size = stacked_transformer_obj.hidden_dims
+        te_transformer_tpl.layernorm_epsilon = stacked_transformer_obj.transformer_layer_params_tpl.ln_tpl.epsilon
+        te_transformer_tpl.dropout_rng_name = base_layer.RANDOM
+        te_transformer_tpl.attention_dropout = stacked_transformer_obj.atten_dropout_prob or stacked_transformer_obj.dropout_prob
+        te_transformer_tpl.hidden_dropout = stacked_transformer_obj.residual_dropout_prob or stacked_transformer_obj.dropout_prob
+        te_transformer_tpl.intermediate_dropout = stacked_transformer_obj.relu_dropout_prob or stacked_transformer_obj.dropout_prob
+        if stacked_transformer_obj.residual_droppath_prob > 0.0:
+            te_transformer_tpl.drop_path = (
+                stacked_transformer_obj.residual_droppath_prob * layer_id / max(1, stacked_transformer_obj.num_layers)
+            )
+
+        assert stacked_transformer_obj.dim_per_head == stacked_transformer_obj.model_dims // stacked_transformer_obj.num_heads
+        assert stacked_transformer_obj.packed_input == False
+        assert len(stacked_transformer_obj.moe_layers) == 0
+        assert stacked_transformer_obj.ngrammer_tpls is None
+
+        return te_transformer_tpl
+
+    @staticmethod
+    def get_bld_mapping_for_pipelined_transformer(_):
+        rules = te_flax.extend_logical_axis_rules(tuple())
+        batch_mapping = rules[0]
+        hidden_tp_mapping = rules[4]
+        # [Batch, Seqlen, Hidden]
+        bld_mapping = [batch_mapping, None, hidden_tp_mapping]
+        return bld_mapping
+
+
+
+
+class TransformerEngineHelper(TransformerEngineHelperBase):
+
+    @staticmethod
+    def is_enabled_te():
+        enable_te = bool(int((os.environ.get("ENABLE_TE", False))))
+        return (_IS_TRANSFORMER_ENGINE_INSTALLED and enable_te)
+
+    @staticmethod
+    def get_helper():
+        if TransformerEngineHelper.is_enabled_te():
+            return TEInstalledHelper
+        return TENotInstalledHelper
+
+    @staticmethod
+    def get_fprop_caller_of_stack_transformer(fprop, deterministic):
+        return TransformerEngineHelper.get_helper().get_fprop_caller_of_stack_transformer(
+                    fprop, deterministic)
+
+    @staticmethod
+    def set_layer_params_to_stack_transformer(stacked_transformer_obj, layer_p, layer_id):
+        return TransformerEngineHelper.get_helper().set_layer_params_to_stack_transformer(
+                    stacked_transformer_obj, layer_p, layer_id)
+
+    @staticmethod
+    def get_bld_mapping_for_pipelined_transformer(xformer_layer_p):
+        return TransformerEngineHelper.get_helper().get_bld_mapping_for_pipelined_transformer(
+                    xformer_layer_p)
+
+

--- a/praxis/layers/transformers.py
+++ b/praxis/layers/transformers.py
@@ -39,6 +39,7 @@ from praxis.layers import pipeline
 from praxis.layers import repeats
 from praxis.layers import stats
 from praxis.layers import stochastics
+from praxis.contrib.gpu.scripts_gpu.te_helper import TransformerEngineHelper
 
 NestedMap = py_utils.NestedMap
 WeightInit = base_layer.WeightInit
@@ -1655,23 +1656,8 @@ class StackedTransformer(base_layer.BaseLayer):
         p_i = self._clone_layer_params(self.transformer_layer_params_tpl[ii])
       else:
         p_i = self._clone_layer_params(self.transformer_layer_params_tpl)
-      p_i.name = f'layer_{i}'
-      p_i.use_cross_attention = self.use_cross_attention
-      p_i.num_heads = self.num_heads
-      p_i.dim_per_head = self.dim_per_head
-      p_i.input_dims = self.model_dims
-      p_i.packed_input = self.packed_input
-      p_i.atten_dropout_prob = self.atten_dropout_prob or self.dropout_prob
-      p_i.residual_dropout_prob = (
-          self.residual_dropout_prob or self.dropout_prob
-      )
-      p_i.relu_dropout_prob = self.relu_dropout_prob or self.dropout_prob
-      p_i.hidden_dims = self.hidden_dims
 
-      if self.residual_droppath_prob > 0.0:
-        p_i.residual_droppath_prob = (
-            self.residual_droppath_prob * i / max(1, self.num_layers)
-        )
+      p_i = TransformerEngineHelper.set_layer_params_to_stack_transformer(self, p_i, i)
 
       if self.moe_layers and i in self.moe_layers:
         assert self.num_experts > 0
@@ -1789,6 +1775,8 @@ class StackedTransformer(base_layer.BaseLayer):
           segment_pos=segment_pos,
       )
       return x_out
+
+    _fprop = TransformerEngineHelper.get_fprop_caller_of_stack_transformer(_fprop, self.do_eval)
 
     fprop = _fprop
     if self.remat:
@@ -2255,7 +2243,7 @@ class PipelinedTransformer(base_layer.BaseLayer):
     else:
       assert self.pipeline_stage.cls == StackedTransformerRepeated
       xformer_layer_p = self.pipeline_stage.block.transformer_layer_params_tpl
-    bld_mapping = xformer_layer_p.tr_atten_tpl.activation_split_dims_mapping.bld
+    bld_mapping = TransformerEngineHelper.get_bld_mapping_for_pipelined_transformer(xformer_layer_p)
     if not self.stream_io:
       # Annotate the inputs before the pipeline to prevent unexpected
       # propagation from earlier layers.


### PR DESCRIPTION
Adds support for NVIDIA's [Transformer Engine](https://github.com/NVIDIA/TransformerEngine). TE can be enabled by setting the environment variable `ENABLE_TE=1`. For more details about running Pax with Transformer Engine, refer to the [JAX Toolbox README](https://github.com/NVIDIA/JAX-Toolbox/blob/main/rosetta/rosetta/projects/pax/README.md).

Requires Paxml PR [#46](https://github.com/google/paxml/pull/46).