### PR TITLE
Grok fp8

### DIFF
--- a/praxis/layers/grok.py
+++ b/praxis/layers/grok.py
@@ -155,19 +155,6 @@ def GrokStackedTransformerHParams(
     tr_atten_tpl.combine_qkv = True
     tr_atten_tpl.combined_qkv_proj_tpl.use_bias = False
     tr_atten_tpl.combined_qkv_proj_tpl.attention_combine_dims = True
-  # Non-MoE ffn setup
-  ff_tpl = p.transformer_layer_params_tpl.tr_fflayer_tpl  # pytype: disable=attribute-error  # enable-nested-classes
-  assert fdl.get_callable(ff_tpl) == transformers.TransformerFeedForward
-  ff_tpl.input_dims = model_dim
-  ff_tpl.hidden_dims = ff_dim
-  ff_tpl.has_bias = False
-  ff_tpl.apply_padding_first = True
-  ff_tpl.ln_tpl = pax_fiddle.Config(normalizations.RmsNorm)
-  ff_tpl.ln_tpl.direct_scale = True
-  ff_tpl.add_skip_connection = True
-  ff_tpl.activation_tpl = ffn_activation_tpl
-  ff_tpl.use_gated_activation = use_gated_activation
-  ff_tpl.internal_gshard_variance_scaling_fan_in_init = True
 
   # MoE ffn setup
   moe_p = p.moe_layer_tpl

--- a/praxis/layers/transformer_models.py
+++ b/praxis/layers/transformer_models.py
@@ -203,7 +203,7 @@ def _set_stacked_transformer_sharding_with_expert_parallelism(
     w_h_sharding = None if w_emh is None else w_emh[2]
     moe_wp.ehm = [w_e_sharding, w_h_sharding, w_m_sharding]
     # Activations
-    a_e_sharding = None if a_egch is None else ('data', 'data_expert')
+    a_e_sharding = None if a_egch is None else ('replica','data', 'data_expert')
     moe_ap = moe_p.activation_split_dims_mapping
     moe_ap.gs = [a_e_sharding, None]
     # dispatch and combine tensors
@@ -211,7 +211,7 @@ def _set_stacked_transformer_sharding_with_expert_parallelism(
     moe_ap.gecs = [a_e_sharding, None, None, None]
     moe_ap.gec = [a_e_sharding, None, None]
     moe_ap.egch = a_egch
-    a_e_sharding = None if a_egcm is None else ('data', 'data_expert')
+    a_e_sharding = None if a_egcm is None else ('replica','data', 'data_expert')
     a_m_sharding = None if a_egcm is None else a_egcm[3]
     moe_ap.gsm = [a_e_sharding, None, a_m_sharding]
     moe_ap.egcm = a_egcm
@@ -435,7 +435,7 @@ class TransformerLm(base_layer.BaseLayer):
         else [batch_axes, None, None]
     )
     egcm = (
-        [data_expert_axis, data_axis, None, mdl_axis]
+        [data_expert_axis, (replica_axis, data_axis), None, mdl_axis]
         if training_optimized
         else [batch_axes, None, None, None]
     )

--- a/praxis/layers/transformers.py
+++ b/praxis/layers/transformers.py
@@ -26,6 +26,7 @@ from jax import numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
 import numpy as np
 from praxis import base_layer
+from praxis.layers import base_ops
 from praxis import gshard_utils
 from praxis import pax_fiddle
 from praxis import py_utils
@@ -660,6 +661,7 @@ class TransformerFeedForwardMoe(base_layer.BaseLayer):
   gating_logit_cap: float = 0.0
   moe_gating_embedding_level: str = 'token'
   use_gated_activation: bool = False
+  einsum_tpl: LayerTpl = template_field(base_ops.EinsumOp)
 
   # SPMD partition related params.
   # M - model_dim, for both inputs and outputs
@@ -823,6 +825,7 @@ class TransformerFeedForwardMoe(base_layer.BaseLayer):
     )
     logging.debug('moe wo WeightHParams %s', wo_pc)
     self.create_variable('wo_0', wo_pc)
+    einsum_tpl: LayerTpl = template_field(base_ops.EinsumOp)
 
   def _split(self, t_in, sharding):
     return base_layer.maybe_shard(t_in, sharding, self.mesh_axis_names)
@@ -1042,8 +1045,8 @@ class TransformerFeedForwardMoe(base_layer.BaseLayer):
     expert_inputs = self._split(expert_inputs, ap.egcm)
 
     if self._is_ffn1_gated:
-      hidden0 = jnp.einsum('egcm,emh->egch', expert_inputs, theta_wi)
-      hidden1 = jnp.einsum('egcm,emh->egch', expert_inputs, theta_wi_gated)
+      hidden0 = self.einsum('egcm,emh->egch', expert_inputs, theta_wi)
+      hidden1 = self.einsum('egcm,emh->egch', expert_inputs, theta_wi_gated)
       if self.gating_func in ['top2', 'expert_choice_v2']:
         self._count_dead_neurons(hidden1, dispatch_tensor)
       hidden1 = self.activation(hidden1)
@@ -1058,13 +1061,13 @@ class TransformerFeedForwardMoe(base_layer.BaseLayer):
     # Dropout.
     hidden = self.relu_dropout(hidden)
     # Output.
-    expert_output = jnp.einsum('egch,ehm->egcm', hidden, theta_wo)
+    expert_output = self.einsum('egch,ehm->egcm', hidden, theta_wo)
     expert_output = self._split(expert_output, ap.egcm)
     # Now transpose and reshard.
     transposed_expert_output = jnp.einsum('egcm->gecm', expert_output)
     transposed_expert_output = self._split(transposed_expert_output, ap.gecm)
     if self.gating_func in ['top2', 'expert_choice_v2']:
-      combined_output = jnp.einsum(
+      combined_output = self.einsum(
           'gecm,gsec->gsm', transposed_expert_output, combine_tensor
       )
     elif self.gating_func == 'expert_choice':

--- a/praxis/layers/transformers.py
+++ b/praxis/layers/transformers.py
@@ -825,7 +825,7 @@ class TransformerFeedForwardMoe(base_layer.BaseLayer):
     )
     logging.debug('moe wo WeightHParams %s', wo_pc)
     self.create_variable('wo_0', wo_pc)
-    einsum_tpl: LayerTpl = template_field(base_ops.EinsumOp)
+    self.create_child('einsum', self.einsum_tpl.clone())
 
   def _split(self, t_in, sharding):
     return base_layer.maybe_shard(t_in, sharding, self.mesh_axis_names)


### PR DESCRIPTION
Add fp8 GeMM support for Grok model. 

Dispatch GeMM is kept in bf16 due to XLA failure, will change it to fp8 once the XLA fix is done.