### PR TITLE
Quantize dispatch gemm to fp8

### DIFF
--- a/praxis/layers/transformers.py
+++ b/praxis/layers/transformers.py
@@ -1031,7 +1031,7 @@ class TransformerFeedForwardMoe(base_layer.BaseLayer):
     if self.gating_func in ['top2', 'expert_choice_v2']:
       combine_tensor = self._split(combine_tensor, ap.gsec)
       dispatch_tensor = self._split(dispatch_tensor, ap.gsec)
-      expert_inputs = jnp.einsum(
+      expert_inputs = self.einsum(
           'gsec,gsm->egcm', dispatch_tensor, reshaped_inputs
       )
     elif self.gating_func == 'expert_choice':


### PR DESCRIPTION
XLA error when apply fp8 to Grok model's dispatch GeMM has been fixed in https://github.com/openxla/xla/pull/13065. So we can quantize dispatch GeMM to fp8.