### PR TITLE
[NVIDIA] Use separate FP8 einsum instances in MoE

### DIFF
--- a/praxis/layers/base_ops.py
+++ b/praxis/layers/base_ops.py
@@ -42,6 +42,17 @@ class EinsumOp(base_layer.BaseLayer):
     return jnp.einsum(equation, *args)
 
 
+class EinsumGatedOp(base_layer.BaseLayer):
+  """Wrapper around two jnp.einsum for gated FFN."""
+
+  def __call__(self, equation: str, *args: JTensor) -> JTensor:
+    assert len(args) == 3
+    x, k, k_gated = args
+    y = jnp.einsum(equation, x, k)
+    y_gated = jnp.einsum(equation, x, k_gated)
+    return y, y_gated
+
+
 class ArrayLookup(base_layer.BaseLayer):
   """Wrapper around array indexing as used in embedding lookup."""
 

--- a/praxis/layers/grok.py
+++ b/praxis/layers/grok.py
@@ -185,9 +185,6 @@ def GrokStackedTransformerHParams(
         fp8_ops.Fp8EinsumOp
     )
     p.moe_layer_tpl.einsum_tpl = pax_fiddle.Config(fp8_ops.Fp8EinsumOp)
-  # p.moe_layer_tpl.einsum_tpl = (
-  #      pax_fiddle.Config(fp8_ops.Fp8EinsumOp)
-  #  )
   return p
 
 

--- a/praxis/layers/grok.py
+++ b/praxis/layers/grok.py
@@ -185,6 +185,9 @@ def GrokStackedTransformerHParams(
         fp8_ops.Fp8EinsumOp
     )
     p.moe_layer_tpl.einsum_tpl = pax_fiddle.Config(fp8_ops.Fp8EinsumOp)
+    p.moe_layer_tpl.einsum_gated_tpl = pax_fiddle.Config(
+        fp8_ops.Fp8EinsumGatedOp
+    )
   return p
 
 

--- a/praxis/layers/injection/fp8_nvidia_gpu.py
+++ b/praxis/layers/injection/fp8_nvidia_gpu.py
@@ -41,6 +41,8 @@ from praxis import layers
 from praxis import pax_fiddle
 from praxis import pytypes
 
+JTensor = pytypes.JTensor
+
 def _get_fp8_args(amax_history_length, mesh_shape):
   OVERWRITE_WITH_GRADIENT = (
       base_layer.WeightHParamsCollection.OVERWRITE_WITH_GRADIENT
@@ -92,18 +94,11 @@ class Fp8EinsumOp(base_layer.BaseLayer):
         'output_grad_scale', base_layer.WeightHParams(**scale_args)
     )
 
-  def __call__(self, equation: str, *args: pytypes.JTensor) -> pytypes.JTensor:
-    assert len(args) == 2
-    x = args[0]
-    k = args[1]
-
-    comp_dtype = self.fprop_dtype
-    assert (
-        k.dtype == comp_dtype
-    ), f'k dtype has to be {comp_dtype}, but got {k.dtype}'
-    x = jnp.asarray(x, comp_dtype)
-
+  def quantized_einsum(
+      self, equation: str, x: JTensor, k: JTensor, return_quantized_x: bool
+  ) -> JTensor | tuple[JTensor, JTensor]:
     theta = self.theta
+    comp_dtype = self.fprop_dtype
 
     x_qdq = fp8_ops.in_qdq(
         comp_dtype,
@@ -129,6 +124,23 @@ class Fp8EinsumOp(base_layer.BaseLayer):
         theta.output_grad_scale,
         theta.output_grad_amax_history,
     )
+
+    if return_quantized_x:
+      return y, x_qdq
+    return y
+
+  def __call__(self, equation: str, *args: JTensor) -> JTensor:
+    assert len(args) == 2
+    x = args[0]
+    k = args[1]
+
+    comp_dtype = self.fprop_dtype
+    assert (
+        k.dtype == comp_dtype
+    ), f'k dtype has to be {comp_dtype}, but got {k.dtype}'
+    x = jnp.asarray(x, comp_dtype)
+
+    y = self.quantized_einsum(equation, x, k, return_quantized_x=False)
 
     return y
 
@@ -156,7 +168,7 @@ class Fp8EinsumGatedOp(Fp8EinsumOp):
         'output_grad_scale_gated', base_layer.WeightHParams(**scale_args)
     )
 
-  def __call__(self, equation: str, *args: pytypes.JTensor) -> pytypes.JTensor:
+  def __call__(self, equation: str, *args: JTensor) -> tuple[JTensor, JTensor]:
     assert len(args) == 3
     x, k, k_gated = args
 
@@ -166,22 +178,10 @@ class Fp8EinsumGatedOp(Fp8EinsumOp):
     ), f'k dtype has to be {comp_dtype}, but got {k.dtype} and {k_gated.dtype}'
     x = jnp.asarray(x, comp_dtype)
 
+    y, x_qdq = self.quantized_einsum(equation, x, k, return_quantized_x=True)
+
     theta = self.theta
 
-    x_qdq = fp8_ops.in_qdq(
-        comp_dtype,
-        jnp.float8_e4m3fn,
-        x,
-        theta.input_scale,
-        theta.input_amax_history,
-    )
-    k_qdq = fp8_ops.in_qdq(
-        comp_dtype,
-        jnp.float8_e4m3fn,
-        k,
-        theta.kernel_scale,
-        theta.kernel_amax_history,
-    )
     k_gated_qdq = fp8_ops.in_qdq(
         comp_dtype,
         jnp.float8_e4m3fn,
@@ -189,19 +189,9 @@ class Fp8EinsumGatedOp(Fp8EinsumOp):
         theta.kernel_scale_gated,
         theta.kernel_amax_history_gated,
     )
-    y_qdq = jnp.einsum(
-        equation, x_qdq, k_qdq, _dot_general=fp8_ops.dot_general_with_precision
-    )
     y_gated_qdq = jnp.einsum(
         equation, x_qdq, k_gated_qdq,
         _dot_general=fp8_ops.dot_general_with_precision
-    )
-    y = fp8_ops.out_qdq(
-        comp_dtype,
-        jnp.float8_e5m2,
-        y_qdq,
-        theta.output_grad_scale,
-        theta.output_grad_amax_history,
     )
     y_gated = fp8_ops.out_qdq(
         comp_dtype,


### PR DESCRIPTION
We found in the original version, the same fp8 einsum op is reused in the MoE by dispatch, FFN, combine gemm ops, meaning they will share the same fp8 meta params, which is wrong.

This PR fixed this issue by cloning the fp8 einsum to each of the gemm in the MoE.

cc. @zhangqiaorjc @abhinavgoel95 @hx89